### PR TITLE
Persist new game state on start

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -126,8 +126,9 @@ export default function Home() {
       skipsUsed: 0,
       maxSkips: gameData.difficulty === 'easy' ? 5 : gameData.difficulty === 'medium' ? 3 : 1
     };
-    
+
     setGameData(newGameData);
+    saveGame(newGameData);
     setUserGuess('');
     setMessage('');
     setGameLoaded(true);


### PR DESCRIPTION
## Summary
- save newly created game data so progress persists after starting a new game

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*
- `npm run dev` *(server started, manual testing required for localStorage persistence)*

------
https://chatgpt.com/codex/tasks/task_b_68ae13032ebc8326add0c314fb8a5e48